### PR TITLE
License Cleanup

### DIFF
--- a/examples/01-words-and-numbers.php
+++ b/examples/01-words-and-numbers.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 require_once './../vendor/autoload.php';
 

--- a/examples/02-math-expressions.php
+++ b/examples/02-math-expressions.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 require_once './../vendor/autoload.php';
 

--- a/examples/03-actions.php
+++ b/examples/03-actions.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 require_once './../vendor/autoload.php';
 

--- a/examples/04-syntax-highlighting.php
+++ b/examples/04-syntax-highlighting.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 require_once './../vendor/autoload.php';
 

--- a/examples/05-reject.php
+++ b/examples/05-reject.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 require_once './../vendor/autoload.php';
 

--- a/readme.md
+++ b/readme.md
@@ -108,29 +108,3 @@ MIT license. Check out `license.txt` and the following section. More information
 ### Why do rules sometimes not get matched correctly?
 You have to ensure that rules that may conflict with each other are listed in the correct order from most specific to most general. For example, if you want to tokenize integers (`[0-9]+`) and floats (`[0-9]+\.[0-9]+`), the rule for floats must be listed before the rule for integers because the integer rule matches the first part of the float rule.
 
-
-
-## Licensing
-
-MIT License
-
-Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-

--- a/src/SilentByte/DynLex/DynLexAction.php
+++ b/src/SilentByte/DynLex/DynLexAction.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexBuilder.php
+++ b/src/SilentByte/DynLex/DynLexBuilder.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexLexer.php
+++ b/src/SilentByte/DynLex/DynLexLexer.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexRule.php
+++ b/src/SilentByte/DynLex/DynLexRule.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexState.php
+++ b/src/SilentByte/DynLex/DynLexState.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexToken.php
+++ b/src/SilentByte/DynLex/DynLexToken.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 

--- a/src/SilentByte/DynLex/DynLexUtils.php
+++ b/src/SilentByte/DynLex/DynLexUtils.php
@@ -1,27 +1,9 @@
 <?php
-////
-//// MIT License
-////
-//// Copyright (c) 2016 SilentByte <https://silentbyte.com/>
-////
-//// Permission is hereby granted, free of charge, to any person obtaining a copy
-//// of this software and associated documentation files (the "Software"), to deal
-//// in the Software without restriction, including without limitation the rights
-//// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//// copies of the Software, and to permit persons to whom the Software is
-//// furnished to do so, subject to the following conditions:
-////
-//// The above copyright notice and this permission notice shall be included in all
-//// copies or substantial portions of the Software.
-////
-//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//// SOFTWARE.
-////
+/**
+ * SilentByte DynLex Lexer Library
+ * @copyright 2016 SilentByte <https://silentbyte.com/>
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace SilentByte\DynLex;
 


### PR DESCRIPTION
Replacing the slash-commented full license text in each PHP file with a file-level docblock with linked copyright and license information improves file readability for both humans and computers (e.g. IDEs and documenter scripts), while maintaining a reference to the license in the file.   Additionally, removing the duplicate license text from the readme.